### PR TITLE
:bug: Wait until uwsgi is running in quickstart job

### DIFF
--- a/.github/workflows/quick-start.yml
+++ b/.github/workflows/quick-start.yml
@@ -6,7 +6,7 @@ on:
       fixtures:
         required: false
         type: string
-        
+
       port:
         required: false
         type: string
@@ -19,11 +19,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Start docker containers
         run: docker compose up -d --build || ( docker compose logs >&2 && exit 1; )
-      - name: Wait for migrations to finish
+      - name: Wait until uWSGI is running
         run: |
-          echo "Waiting for migrations to complete..."
-          until ! docker compose exec -T web src/manage.py showmigrations | grep -q '\[ \]'; do
-            echo "Migrations not finished, waiting..."
+          until docker compose logs web | grep -q "spawned uWSGI worker"; do
+            echo "uWSGI not running yet, waiting..."
             sleep 3
           done
       - name: Load fixtures
@@ -36,4 +35,4 @@ jobs:
             printf "Index page responds with ${curl_status} status.\r\n\r\n" >&2
             curl -i http://localhost:${{ inputs.port }}
             exit 1
-          fi 
+          fi


### PR DESCRIPTION
previously we waited on migrations to be done, but this can cause the job to try to connect too soon (before the app is running)