### PR TITLE
Modularize the OAS actions/workflows

### DIFF
--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -1,0 +1,178 @@
+# Run quality control on the (generated) Open API specification.
+#
+# This workflow is intended to replace:
+# - generate-postman-collection.yml
+# - generate-sdks.yml
+# - lint-oas.yml
+# - oas-check.yml
+#
+# The OAS must:
+# * not be outdated w/r to the code from which it is generated
+# * not have any linting errors
+# * be valid input to generate a Postman collection
+# * be valid input to generate SDKs in commonly used languages/frameworks
+#
+# When dealing with multiple versions, you can adapt this workflow to run a matrix and
+# pass arguments down that way, and/or use a parent workflow to call this workflow for
+# each matrix item. See https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+name: "Check OAS"
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        type: string
+        required: false
+        description: Python version, passed to actions/setup-python
+        default: '3.12'
+
+      django-settings-module:
+        required: true
+        type: string
+
+      oas-generate-command:
+        type: string
+        required: false
+        description: >
+          (Binary) command to run to generate the schema. If working-directory is specified,
+          it's relative to this directory.
+        default: 'bin/generate_schema.sh'
+
+      schema-path:
+        type: string
+        required: false
+        description: Location of the OAS file, relative to working-directory if specified.
+        default: 'src/openapi.yaml'
+
+      oas-artifact-name:
+        type: string
+        required: false
+        description: Name for the artifact of the generated schema.
+        default: generated-oas
+
+      apt-packages:
+        type: string
+        required: false
+        description: Any additional apt packages to install, space-separated
+        default: ''
+
+      working-directory:
+        type: string
+        required: false
+        description: Specifies the working directory where commands are run.
+        default: ''
+
+      node-version-file:
+        type: string
+        required: false
+        description: >2
+          Passed down to actions/setup-node, so the same rules apply. Alternatively, use
+          `node-version` instead.
+        default: ''
+
+      node-version:
+        type: string
+        required: false
+        description: >2
+          Passed down to actions/setup-node, so the same rules apply. Alternatively, use
+          `node-version-file` instead.
+        default: ''
+
+      spectral-version:
+        type: string
+        required: false
+        description: >2
+          The NPM package version number of spectral-cli to install. It's recommended
+          to pin this for stability reasons.
+        default: '^6.15.0'
+
+      spectral-ruleset:
+        type: string
+        required: false
+        description: >2
+          Path or URL to the ruleset to use. The default value (`.spectral.yaml`) is created
+          if it doesn't exist.
+        default: .spectral.yaml
+
+      openapi-to-postman-version:
+        type: string
+        required: false
+        description: >2
+          The NPM package version number of openapi-to-postmanv2 to install. It's recommended
+          to pin this for stability reasons.
+        default: '^5.0.0'
+
+      postman-artifact-name:
+        type: string
+        required: false
+        description: >2
+          Name of the artifact to upload with the generated collection. Artifact uploads are
+          skipped if no name is provided.
+        default: ''
+
+jobs:
+
+  generate-and-compare:
+    name: Generate OAS and check staleness
+    runs-on: ubuntu-latest
+
+    outputs:
+      schema-path: ${{ steps.generate.outputs.schema-path }}
+
+    steps:
+      - name: Generate
+        uses: maykinmedia/open-api-workflows/actions/oas-generate@refactor/reusable-actions
+        id: generate
+        with:
+          python-version: ${{ inputs.python-version }}
+          command: ${{ inputs.oas-generate-command }}
+          artifact-name: ${{ inputs.oas-artifact-name }}
+          schema-path: ${{ inputs.schema-path }}
+          apt-packages: ${{ inputs.apt-packages }}
+          working-directory: ${{ inputs.working-directory }}
+        env:
+          DJANGO_SETTINGS_MODULE: ${{ inputs.django-settings-module }}
+
+      - name: Compare
+        uses: maykinmedia/open-api-workflows/actions/oas-compare@refactor/reusable-actions
+        with:
+          artifact-name: ${{ inputs.oas-artifact-name }}
+          schema-path: ${{ inputs.schema-path }}
+          working-directory: ${{ inputs.working-directory }}
+
+  lint:
+    name: Lint OAS
+    runs-on: ubuntu-latest
+    needs:
+      - generate-and-compare  # no point in linting something that's not up to date
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint
+        uses: maykinmedia/open-api-workflows/actions/oas-lint@refactor/reusable-actions
+        with:
+          schema-path: ${{ needs.generate-and-compare.outputs.schema-path }}
+          node-version-file: ${{ inputs.node-version-file }}
+          node-version: ${{ inputs.node-version }}
+          spectral-version: ${{ inputs.spectral-version }}
+          spectral-ruleset: ${{ inputs.spectral-ruleset }}
+
+  postman-collection:
+    name: Generate Postman collection
+    runs-on: ubuntu-latest
+    needs:
+      - generate-and-compare  # no point in linting something that's not up to date
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate collection
+        uses: maykinmedia/open-api-workflows/actions/oas-to-postman@refactor/reusable-actions
+        with:
+          schema-path: ${{ needs.generate-and-compare.outputs.schema-path }}
+          node-version-file: ${{ inputs.node-version-file }}
+          node-version: ${{ inputs.node-version }}
+          openapi-to-postman-version: ${{ inputs.openapi-to-postman-version }}
+          artifact-name: ${{ postman-artifact-name }}
+
+  # TODO: SDK generation

--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -111,6 +111,22 @@ on:
           skipped if no name is provided.
         default: ''
 
+      openapi-generator-version:
+        type: string
+        required: false
+        description: >2
+          The NPM package version number of @openapitools/openapi-generator-cli to install.
+          It's recommended to pin this for stability reasons.
+        default: '^2.20.0'
+
+      openapi-generator-config:
+        type: string
+        required: false
+        description: >2
+          Path or URL to the config to use. The default value (`openapitools.json`) is created
+          if it doesn't exist.
+        default: openapitools.json
+
 jobs:
 
   generate-and-compare:
@@ -173,6 +189,22 @@ jobs:
           node-version-file: ${{ inputs.node-version-file }}
           node-version: ${{ inputs.node-version }}
           openapi-to-postman-version: ${{ inputs.openapi-to-postman-version }}
-          artifact-name: ${{ postman-artifact-name }}
+          artifact-name: ${{ inputs.postman-artifact-name }}
 
-  # TODO: SDK generation
+  sdks:
+    name: Generate SDKS
+    runs-on: ubuntu-latest
+
+    needs:
+      - generate-and-compare  # no point in linting something that's not up to date
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: SDK generation
+        uses: maykinmedia/open-api-workflows/actions/oas-sdks@refactor/reusable-actions
+        with:
+          schema-path: ${{ needs.generate-and-compare.outputs.schema-path }}
+          node-version-file: ${{ inputs.node-version-file }}
+          node-version: ${{ inputs.node-version }}
+          openapi-generator-version: ${{ inputs.openapi-generator-version }}
+          config: ${{ inputs.openapi-generator-config }}

--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -172,7 +172,7 @@ jobs:
           node-version-file: ${{ inputs.node-version-file }}
           node-version: ${{ inputs.node-version }}
           spectral-version: ${{ inputs.spectral-version }}
-          spectral-ruleset: ${{ inputs.spectral-ruleset }}
+          ruleset: ${{ inputs.spectral-ruleset }}
 
   postman-collection:
     name: Generate Postman collection

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # open-api-workflows
-[Reusable workflows](/.github/workflows/) for several open-api related projects.
-The workflows consists of several jobs which ran similiar across several different
-repositories.
 
-## Usage
+[Reusable workflows](/.github/workflows/) and [actions](./actions) for projects that
+implement an API.
+
+The re-usable workflows compose a number of jobs that should be kept similar across
+a multitude of repositories, while the actions provide lower-level building blocks
+that are also useful in projects that aren't purely API-focused.
+
+## Usage (workflows)
 
 ```yaml
 # ci.yml

--- a/actions/extract-version/README.md
+++ b/actions/extract-version/README.md
@@ -1,0 +1,22 @@
+# Extract version information
+
+Small script/action to extract `version` and `git_sha` outputs from the Git and Github
+state that triggered the job/workflow.
+
+Typically you want to collect this information once and then re-use it to tag your
+build artifacts like Docker images, or you may need to derive other information from it.
+
+## Example usage
+
+```yaml
+jobs:
+  setup:
+    name: Set up the build variables
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.vars.outputs.version }}
+      git_hash: ${{ steps.vars.outputs.git_hash }}
+    steps:
+      - uses: maykinmedia/open-api-workflows/actions/extract-version@refactor/reusable-actions
+        id: vars
+```

--- a/actions/extract-version/action.yml
+++ b/actions/extract-version/action.yml
@@ -1,0 +1,51 @@
+---
+
+name: Extract version information from the git state
+
+description: >2
+  Given the checked out repository and github event, determine which "version" is being
+  built in CI.
+
+  Pull requests and builds on the default branch (main/master) resolve to the version
+  `latest`, while git tags are used as value for the version (after stripping a `v` prefix
+  if present).
+
+  The action outputs two variables: `version` and `git_hash` that you can use in the
+  rest of your job/workflow.
+
+inputs: {}
+
+outputs:
+  version:
+    value: ${{ steps.vars.outputs.version }}
+    description: >2
+      The resolved version - either a version number for tags, or 'latest' for
+      pull requests and pushes to the default branch.
+  git_hash:
+    value: ${{ steps.vars.outputs.git_hash }}
+    description: >2
+      The git SHA calculated by Github - for pull requests this will be the commit hash
+      of the merge commit.
+
+runs:
+  using: composite
+
+  steps:
+    - name: Extract version information
+      id: vars
+      run: |
+        # Strip git ref prefix from version
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+        # Strip "v" prefix from tag name (if present at all)
+        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+        # Use Docker `latest` tag convention
+        [ "$VERSION" == "${{ github.event.repository.default_branch }}" ] && VERSION=latest
+
+        # PRs result in version 'merge' -> transform that into 'latest'
+        [ "$VERSION" == "merge" ] && VERSION=latest
+
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+        echo "git_hash=${GITHUB_SHA}" >> $GITHUB_OUTPUT
+      shell: bash

--- a/actions/oas-compare/README.md
+++ b/actions/oas-compare/README.md
@@ -1,0 +1,36 @@
+# OpenAPI comparison
+
+Compare the generated API spec with the version tracked in the repository.
+
+The action fails if differences are found, pointing out oversights of the author. This
+requires a job or step to have completed for the generation of the API spec, see the
+`oas-generate` action.
+
+## Example usage
+
+```yaml
+env:
+  DJANGO_SETTINGS_MODULE: myproject.conf.ci
+
+jobs:
+  generate-and-compare:
+    name: Generate API specification
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: maykinmedia/open-api-workflows/actions/oas-generate@main
+        id: generate
+        with:
+          working-directory: backend
+          artifact-name: openapi-yaml
+          schema-path: src/myproject/api/openapi.yaml
+
+      - uses: maykinmedia/open-api-workflows/actions/oas-compare@main
+        with:
+          working-directory: backend
+          artifact-name: openapi-yaml
+          schema-path: src/myproject/api/openapi.yaml
+```
+
+All inputs are optional, but recommended to specify explicitly.
+

--- a/actions/oas-compare/action.yml
+++ b/actions/oas-compare/action.yml
@@ -1,0 +1,53 @@
+---
+
+name: Compare a generated OpenAPI specification against the version tracked in git.
+
+description: >2
+  Check out the repository and download the generated API specification. Then, check
+  if there are any differences between the versioned and generated API specs.
+
+  Requires the artifact to exist, ideally generated from the `oas-generate` action.
+
+inputs:
+  schema-path:
+    type: string
+    required: false
+    description: Location of the OAS file, relative to working-directory if specified.
+    default: 'src/openapi.yaml'
+
+  artifact-name:
+    type: string
+    required: false
+    description: Name for the artifact of the generated schema.
+    default: generated-oas
+
+  working-directory:
+    type: string
+    required: false
+    description: Specifies the working directory where commands are run.
+    default: ''
+
+runs:
+  using: composite
+
+  steps:
+    - uses: actions/checkout@v4
+    - name: Download generated OAS
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+
+    - name: Check for OAS changes
+      run: |
+        git diff --exit-code ${{ inputs.schema-path }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - name: Write failure markdown
+      if: ${{ failure() }}
+      run: |
+        first_lineno=$(git diff -U0 ${{ inputs.schema-path }} | grep '^@@' | head -1 | sed -E 's/.*\+([0-9]+).*/\1/')
+        filepath="${{ inputs.working-directory != '' && format('{0}/{1}', inputs.working-directory, inputs.schema-path) || inputs.schema-path }}"
+        echo "::error file=$filepath,line=$first_lineno,title=Outdated::There are changes detected in the OpenAPI specification"
+        echo 'Please make sure to re-generate the schema locally and commit the changes.' >> $GITHUB_STEP_SUMMARY
+      shell: bash

--- a/actions/oas-generate/README.md
+++ b/actions/oas-generate/README.md
@@ -1,0 +1,33 @@
+# Generate OpenAPI specification
+
+Generate and upload the OpenAPI spefication.
+
+This action takes care of generating the API specification from the code of your
+project. Once generated, it is uploaded as an artifact.
+
+## Example usage
+
+```yaml
+env:
+  DJANGO_SETTINGS_MODULE: myproject.conf.ci
+
+jobs:
+  generate:
+    name: Generate API specification
+    runs-on: ubuntu-latest
+
+    outputs:
+      schema-path: ${{ steps.generate.outputs.schema-path }}
+
+    steps:
+      - uses: maykinmedia/open-api-workflows/actions/oas-generate@main
+        id: generate
+        with:
+          python-version: '3.12'
+          working-directory: backend
+          command: bin/generate_api_schema.sh --language en
+          artifact-name: openapi-yaml
+          schema-path: src/myproject/api/openapi.yaml
+```
+
+All inputs are optional, but recommended to specify explicitly.

--- a/actions/oas-generate/action.yml
+++ b/actions/oas-generate/action.yml
@@ -1,0 +1,98 @@
+---
+
+name: Generate the OpenAPI specification from source
+
+description: >2
+  Check out the repository and generate the API specification from the source code.
+
+  Any environment variables set on the job or workflow are available, so use that to
+  specify `DJANGO_SETTINGS_MODULE` accordingly.
+
+
+  The result is uploaded as Github artifact so that it can be re-used in other steps
+  without needing to re-generate it all the time.
+
+inputs:
+  # inputs for the generation itself
+  command:
+    type: string
+    required: false
+    description: >
+      (Binary) command to run to generate the schema. If working-directory is specified,
+      it's relative to this directory.
+    default: 'bin/generate_schema.sh'
+
+  schema-path:
+    type: string
+    required: false
+    description: Location of the OAS file, relative to working-directory if specified.
+    default: 'src/openapi.yaml'
+
+  artifact-name:
+    type: string
+    required: false
+    description: Name for the artifact of the generated schema.
+    default: generated-oas
+
+  # inputs for maykinmedia/setup-django-backend
+  python-version:
+    type: string
+    required: false
+    description: Python version, passed to actions/setup-python
+    default: '3.12'
+
+  apt-packages:
+    type: string
+    required: false
+    description: Any additional apt packages to install, space-separated
+    default: ''
+
+  working-directory:
+    type: string
+    required: false
+    description: Specifies the working directory where commands are run.
+    default: ''
+
+outputs:
+  schema-path:
+    description: >
+      Calculated (relative) path of the generated schema to the repository root.
+    value: ${{ steps.calculate-schema-path.outputs.schema-path }}
+
+runs:
+  using: composite
+
+  steps:
+    - uses: actions/checkout@v4
+    - name: Set up backend environment
+      uses: maykinmedia/setup-django-backend@v1.3
+      with:
+        python-version: ${{ inputs.python-version }}
+        apt-packages: gettext ${{ inputs.apt-packages }}
+        working-directory: ${{ inputs.working-directory }}
+        optimize-postgres: 'no'
+        setup-node: 'no'
+
+    - name: Generate the API specification
+      run: |
+        src/manage.py compilemessages
+        ${{ inputs.command }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+
+    - name: Calculate schema path relative to repository root
+      id: calculate-schema-path
+      run: |
+        echo "schema-path=${{ inputs.working-directory != '' && format('{0}/{1}', inputs.working-directory, inputs.schema-path) || inputs.schema-path }}" >> $GITHUB_OUTPUT
+        touch .gitkeep
+      shell: bash
+
+    - name: Store generated API specification for later use
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        # jeez github... https://github.com/actions/upload-artifact/issues/174
+        path: |
+          ${{ steps.calculate-schema-path.outputs.schema-path }}
+          .gitkeep
+        retention-days: 1

--- a/actions/oas-lint/README.md
+++ b/actions/oas-lint/README.md
@@ -1,0 +1,43 @@
+# Lint OpenAPI specification
+
+Run the [spectral](https://www.npmjs.com/package/@stoplight/spectral-cli) linter on the
+specified OpenAPI specification.
+
+This action deliberately does not use the existing github action, as it appears to not
+be maintained.
+
+## Example usage
+
+```yaml
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    outputs:
+      schema-path: ${{ steps.generate.outputs.schema-path }}
+
+    steps:
+      - uses: maykinmedia/open-api-workflows/actions/oas-generate@refactor/reusable-actions
+        id: generate
+        with:
+          artifact-name: my-project-oas
+
+  lint:
+    runs-on: ubuntu-latest
+    needs:
+      - generate
+
+    steps:
+      - name: Download generated OAS
+        uses: actions/download-artifact@v4
+        with:
+          name: my-project-oas
+      - uses: maykinmedia/open-api-workflows/actions/oas-lint@refactor/reusable-actions
+        with:
+          schema-path: ${{ needs.generate.outputs.schema-path }}
+          node-version-file: '.nvmrc'
+          spectral-version: '^6.15.0'
+```
+
+Note that if you cleverly combine all the actions that you don't even need to check out
+the repository.

--- a/actions/oas-lint/action.yml
+++ b/actions/oas-lint/action.yml
@@ -1,0 +1,74 @@
+---
+
+name: Lint the specified OpenAPI spec using spectral.
+
+description: >2
+  Installs and runs the spectral linter on the specified OpenAPI specification(s).
+
+
+  You can provide the API specification in a number of ways: checkout the repository
+  using actions/checkout, or download an earlier generated artifact. This action does
+  *not* run the checkout itself.
+
+inputs:
+  schema-path:
+    type: string
+    required: true
+    description: Path or glob (relative to the root of the repo) of specifications to lint.
+    default: 'src/openapi.yaml'
+
+  node-version-file:
+    type: string
+    required: false
+    description: >2
+      Passed down to actions/setup-node, so the same rules apply. Alternatively, use
+      `node-version` instead.
+    default: ''
+
+  node-version:
+    type: string
+    required: false
+    description: >2
+      Passed down to actions/setup-node, so the same rules apply. Alternatively, use
+      `node-version-file` instead.
+    default: ''
+
+  spectral-version:
+    type: string
+    required: false
+    description: >2
+      The NPM package version number of spectral-cli to install. It's recommended
+      to pin this for stability reasons.
+    default: '^6.15.0'
+
+  ruleset:
+    type: string
+    required: false
+    description: >2
+      Path or URL to the ruleset to use. The default value (`.spectral.yaml`) is created
+      if it doesn't exist.
+    default: .spectral.yaml
+
+runs:
+  using: composite
+
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version-file }}
+
+    - name: Set up (default) ruleset
+      run: |
+        if [ ! -f .spectral.yaml ]; then
+          echo 'Creating default ruleset'
+          echo 'extends: ["spectral:oas"]' > .spectral.yaml
+        fi
+      shell: bash
+
+    - name: Install and run Spectral linter
+      run: |
+        npm install -g @stoplight/spectral-cli@${{ inputs.spectral-version }}
+        spectral lint ${{ inputs.schema-path }} --ruleset ${{ inputs.ruleset }}
+      shell: bash

--- a/actions/oas-sdks/README.md
+++ b/actions/oas-sdks/README.md
@@ -1,0 +1,55 @@
+# Generate SDKs from the OpenAPI specification
+
+Given an OpenAPI specification, generate SDKs in a variety of languages/frameworks.
+
+This action helps ensure that the API specification can be used for code generation in
+popular frameworks/stacks.
+
+## Example usage
+
+```yaml
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    outputs:
+      schema-path: ${{ steps.generate.outputs.schema-path }}
+
+    steps:
+      - uses: maykinmedia/open-api-workflows/actions/oas-generate@refactor/reusable-actions
+        id: generate
+        with:
+          artifact-name: my-project-oas
+
+  sdks:
+    runs-on: ubuntu-latest
+    needs:
+      - generate
+
+    steps:
+      - name: Download generated OAS
+        uses: actions/download-artifact@v4
+        with:
+          name: my-project-oas
+      - uses: maykinmedia/open-api-workflows/actions/oas-sdks@refactor/reusable-actions
+        with:
+          schema-path: ${{ needs.generate.outputs.schema-path }}
+          node-version-file: '.nvmrc'
+          spectral-version: '^6.15.0'
+```
+
+Note that if you cleverly combine all the actions that you don't even need to check out
+the repository.
+
+## Maintenance
+
+The `openapitools.json` file is used for the default configuration. It is not
+automatically loaded, but kept as a separate file so there's a least syntax highlighting
+and syntax checking in editors. Make sure to copy it into the `action.yml` after making
+changes. Be careful to escape dollar signs where needed!
+
+Periodically you can check if there are new generator versions:
+
+```bash
+openapi-generator-cli version-manager list
+```

--- a/actions/oas-sdks/action.yml
+++ b/actions/oas-sdks/action.yml
@@ -1,0 +1,147 @@
+---
+
+name: Lint the specified OpenAPI spec using spectral.
+
+description: >2
+  Installs and runs the spectral linter on the specified OpenAPI specification(s).
+
+
+  You can provide the API specification in a number of ways: checkout the repository
+  using actions/checkout, or download an earlier generated artifact. This action does
+  *not* run the checkout itself.
+
+inputs:
+  schema-path:
+    type: string
+    required: true
+    description: Path or glob (relative to the root of the repo) of specifications to lint.
+    default: 'src/openapi.yaml'
+
+  node-version-file:
+    type: string
+    required: false
+    description: >2
+      Passed down to actions/setup-node, so the same rules apply. Alternatively, use
+      `node-version` instead.
+    default: ''
+
+  node-version:
+    type: string
+    required: false
+    description: >2
+      Passed down to actions/setup-node, so the same rules apply. Alternatively, use
+      `node-version-file` instead.
+    default: ''
+
+  openapi-generator-version:
+    type: string
+    required: false
+    description: >2
+      The NPM package version number of @openapitools/openapi-generator-cli to install.
+      It's recommended to pin this for stability reasons.
+    default: '^2.20.0'
+
+  config:
+    type: string
+    required: false
+    description: >2
+      Path or URL to the config to use. The default value (`openapitools.json`) is created
+      if it doesn't exist.
+    default: openapitools.json
+
+runs:
+  using: composite
+
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version-file }}
+
+    # Cache this package, because it needs to download stuff from Maven which breaks
+    # all the time.
+    - name: Cache global npm packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm-global
+        key: npm-global-${{ runner.os }}-${{ inputs.openapi-generator-version }}
+
+    - name: Set up (default) config file
+      run: |
+        if [ ! -f openapitools.json ]; then
+          echo 'Creating default config'
+
+          cat << "EOF" > openapitools.json
+        {
+          "$schema": "~/.npm-global/@openapitools/openapi-generator-cli/config.schema.json",
+          "spaces": 2,
+          "generator-cli": {
+            "version": "7.13.0",
+            "generators": {
+              "java": {
+                "generatorName": "java",
+                "inputSpec": "${{ inputs.schema-path }}",
+                "output": "#{cwd}/sdks/java",
+                "globalProperty": {
+                  "modelTests": false,
+                  "apiTests": false,
+                  "modelDocs": false,
+                  "apiDocs": false
+                },
+                "additionalProperties": {
+                  "dateLibrary": "java8"
+                }
+              },
+              ".net": {
+                "generatorName": "csharp",
+                "inputSpec": "${{ inputs.schema-path }}",
+                "output": "#{cwd}/sdks/dotnet",
+                "globalProperty": {
+                  "modelTests": false,
+                  "apiTests": false,
+                  "modelDocs": false,
+                  "apiDocs": false
+                },
+                "additionalProperties": {
+                  "optionalProjectFile": false,
+                  "optionalAssemblyInfo": false
+                }
+              },
+              "python": {
+                "generatorName": "python",
+                "inputSpec": "${{ inputs.schema-path }}",
+                "output": "#{cwd}/sdks/python",
+                "globalProperty": {
+                  "modelTests": false,
+                  "apiTests": false,
+                  "modelDocs": false,
+                  "apiDocs": false
+                },
+                "additionalProperties": {}
+              }
+            }
+          }
+        }
+        EOF
+
+        fi
+      shell: bash
+
+    - name: Install @openapitools/openapi-generator-cli
+      run: |
+        # Set up global path
+        npm config set prefix ~/.npm-global
+        echo "$HOME/.npm-global/bin" >> $GITHUB_PATH
+
+        # And install the package
+        npm install -g @openapitools/openapi-generator-cli@${{ inputs.openapi-generator-version }}
+        # Ensure that the Java package is installed, which saves it in the package directory
+        ~/.npm-global/bin/openapi-generator-cli help
+      shell: bash
+
+    - name: Run validator and generator
+      run: |
+        openapi-generator-cli --openapitools ${{ inputs.config }} validate --input-spec ${{ inputs.schema-path }}
+        openapi-generator-cli --openapitools ${{ inputs.config }} generate
+      shell: bash

--- a/actions/oas-sdks/openapitools.json
+++ b/actions/oas-sdks/openapitools.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "~/.npm-global/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.13.0",
+    "generators": {
+      "java": {
+        "generatorName": "java",
+        "inputSpec": "${{ inputs.schema-path }}",
+        "output": "#{cwd}/sdks/java",
+        "globalProperty": {
+          "modelTests": false,
+          "apiTests": false,
+          "modelDocs": false,
+          "apiDocs": false
+        },
+        "additionalProperties": {
+          "dateLibrary": "java8"
+        }
+      },
+      ".net": {
+        "generatorName": "csharp",
+        "inputSpec": "${{ inputs.schema-path }}",
+        "output": "#{cwd}/sdks/dotnet",
+        "globalProperty": {
+          "modelTests": false,
+          "apiTests": false,
+          "modelDocs": false,
+          "apiDocs": false
+        },
+        "additionalProperties": {
+          "optionalProjectFile": false,
+          "optionalAssemblyInfo": false
+        }
+      },
+      "python": {
+        "generatorName": "python",
+        "inputSpec": "${{ inputs.schema-path }}",
+        "output": "#{cwd}/sdks/python",
+        "globalProperty": {
+          "modelTests": false,
+          "apiTests": false,
+          "modelDocs": false,
+          "apiDocs": false
+        },
+        "additionalProperties": {}
+      }
+    }
+  }
+}

--- a/actions/oas-to-postman/README.md
+++ b/actions/oas-to-postman/README.md
@@ -1,0 +1,41 @@
+# Generate Postman collection from an OpenAPI specification
+
+Take the provided API specification and verify that a Postman collection can be
+generated successfully. The collection is uploaded as artifact so you can download and
+test it.
+
+## Example usage
+
+```yaml
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    outputs:
+      schema-path: ${{ steps.generate.outputs.schema-path }}
+
+    steps:
+      - uses: maykinmedia/open-api-workflows/actions/oas-generate@refactor/reusable-actions
+        id: generate
+        with:
+          artifact-name: my-project-oas
+
+  lint:
+    runs-on: ubuntu-latest
+    needs:
+      - generate
+
+    steps:
+      - name: Download generated OAS
+        uses: actions/download-artifact@v4
+        with:
+          name: my-project-oas
+      - uses: maykinmedia/open-api-workflows/actions/oas-to-postman@refactor/reusable-actions
+        with:
+          schema-path: ${{ needs.generate.outputs.schema-path }}
+          node-version-file: '.nvmrc'
+          openapi-to-postman-version: '^5.0.0'
+```
+
+Note that if you cleverly combine all the actions that you don't even need to check out
+the repository.

--- a/actions/oas-to-postman/action.yml
+++ b/actions/oas-to-postman/action.yml
@@ -1,0 +1,75 @@
+---
+
+name: Generate Postman collection from an OpenAPI specification
+
+description: >2
+  Take the provided API specification and verify that a Postman collection can be
+  generated successfully. The collection is uploaded as artifact so you can download and
+  test it.
+
+inputs:
+  schema-path:
+    type: string
+    required: true
+    description: Path or glob (relative to the root of the repo) of specifications to lint.
+    default: 'src/openapi.yaml'
+
+  node-version-file:
+    type: string
+    required: false
+    description: >2
+      Passed down to actions/setup-node, so the same rules apply. Alternatively, use
+      `node-version` instead.
+    default: ''
+
+  node-version:
+    type: string
+    required: false
+    description: >2
+      Passed down to actions/setup-node, so the same rules apply. Alternatively, use
+      `node-version-file` instead.
+    default: ''
+
+  openapi-to-postman-version:
+    type: string
+    required: false
+    description: >2
+      The NPM package version number of openapi-to-postmanv2 to install. It's recommended
+      to pin this for stability reasons.
+    default: '^5.0.0'
+
+  artifact-name:
+    type: string
+    required: false
+    description: >2
+      Name of the artifact to upload with the generated collection. Artifact uploads are
+      skipped if no name is provided.
+    default: ''
+
+runs:
+  using: composite
+
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version-file }}
+
+    - name: Install and run collection generator
+      run: |
+        npm install -g openapi-to-postmanv2@${{ inputs.openapi-to-postman-version }}
+        mkdir -p ${{ runner.temp }}/postman/
+        openapi2postmanv2 \
+          --spec ${{ inputs.schema-path }} \
+          --output ${{ runner.temp }}/postman/collection.json \
+          --pretty
+      shell: bash
+
+    - name: Upload artifact
+      if: inputs.artifact-name != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ runner.temp }}/postman/collection.json
+        retention-days: 1


### PR DESCRIPTION
So, reason for these changes is that we essentially have some interesting snippets that would benefit from being centralized, while still allowing flexibility. Personally, I want to stop maintaining repeated CI code in https://github.com/GPP-Woo/gpp-zoeken and https://github.com/GPP-Woo/gpp-publicatiebank, but also in https://github.com/open-formulieren/open-forms which _also_ publishes its API checks and performs this kind of quality control on them.

I've tried to do this in a way that should not be too invasive and still offer great flexibility.

**My design constraints I've taken into account are**

* a single place where the used tools are known/managed (with tools like spectral, drf-spectacular, openapi-generator...)
* use the same pattern, but allow customizing details to fit the project that's using it
* support split and monorepo's - if the backend lives in the `backend` directory, that should still work (currently untested)
* make it easy to do the common stuff without having to worry about it, while providing escape hatches otherwise
* have efficient CI pipelines and use of the runners

**The approach I've taken for this is**

* what are now separate jobs in most of my projects and even separate workflows in team bron projects (the existing workflows in this repo) become composite actions
* the OAS generation should only happen once and stored in an artifact that can be re-used
* each action is documented and has its input parameters defined
* there's a single workflow that uses these actions so you can easily run a battle-tested setup. if you want to tinker around with dependencies/order of operations, you can create your own workflow in your project based on the composite actions

**Validation**

I'm running these actions and/or workflows in several projects to verify that this setup works for (almost) everyone. Below the status of each project:

- ✅ - [GPP-Woo/gpp-zoeken](https://github.com/GPP-Woo/GPP-zoeken/pull/86)
- ✅ - [open-formulieren/open-forms](https://github.com/open-formulieren/open-forms/pull/5322)
- ~~maykinmedia/open-archiefbeheer~~ monorepo, but they don't seem to publish their OAS
- ✅ - [open-zaak/open-zaak](https://github.com/open-zaak/open-zaak/pull/2028)
- ✅ - [maykinmedia/objects-api](https://github.com/maykinmedia/objects-api/pull/595) & [objecttypes-api](https://github.com/maykinmedia/objecttypes-api/pull/175)
- ✅ - [maykinmedia/open-klant](https://github.com/maykinmedia/open-klant/pull/421)