### PR TITLE
:construction_worker: [maykinmedia/open-api-framework#132] Run docs tests via make instead of pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,8 @@ jobs:
           OPENSSL_CONF: ${{ inputs.docs-ssl-conf }}
           DJANGO_SETTINGS_MODULE: ${{ inputs.django-settings-module }}
         run: |
-          pytest check_sphinx.py --verbose --tb=auto
+          make SPHINXOPTS="-W" html
+          make linkcheck
         working-directory: docs
 
   docker-build:


### PR DESCRIPTION
Fixes https://github.com/maykinmedia/open-api-framework/issues/132