### PR TITLE
:heavy_plus_sign: [#60] Replace spectral-cli with go-based vacuum for OAS lint job

### DIFF
--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -79,13 +79,26 @@ on:
           `node-version-file` instead.
         default: ''
 
-      spectral-version:
+      vacuum-version:
         type: string
         required: false
         description: >2
-          The NPM package version number of spectral-cli to install. It's recommended
-          to pin this for stability reasons.
-        default: '^6.15.0'
+          The version of vacuum to install. It's recommended to pin this for stability reasons.
+        default: '0.30.0'
+
+      vacuum-version-checksum:
+        type: string
+        required: false
+        description: >2
+          The sha256 checksum that should match for the given `vacuum-version`
+        default: '2dac5adb73fe190e2657108f2ab408fafbc0fe5323b33825b03a6537de0207c8'  # checksum for 0.30.0
+
+      vacuum-hard-mode:
+        type: boolean
+        required: false
+        description: >2
+          Whether or not the --hard-mode flag should be enabled for vacuum linting
+        default: false
 
       spectral-ruleset:
         type: string
@@ -172,9 +185,9 @@ jobs:
         uses: maykinmedia/open-api-workflows/actions/oas-lint@cca0942e0fac0e83da00e8d3b9bbf540a9b06c7e # pre-v7.0.0
         with:
           schema-path: ${{ needs.generate-and-compare.outputs.schema-path }}
-          node-version-file: ${{ inputs.node-version-file }}
-          node-version: ${{ inputs.node-version }}
-          spectral-version: ${{ inputs.spectral-version }}
+          vacuum-version: ${{ inputs.vacuum-version }}
+          vacuum-version-checksum: ${{ inputs.vacuum-version-checksum }}
+          vacuum-hard-mode: ${{ inputs.vacuum-hard-mode }}
           ruleset: ${{ inputs.spectral-ruleset }}
 
   postman-collection:

--- a/.github/workflows/oas.yml
+++ b/.github/workflows/oas.yml
@@ -91,7 +91,7 @@ on:
         required: false
         description: >2
           The sha256 checksum that should match for the given `vacuum-version`
-        default: '2dac5adb73fe190e2657108f2ab408fafbc0fe5323b33825b03a6537de0207c8'  # checksum for 0.30.0
+        default: '817b6bd71051c2b543891b4e26692404bfab9c79b29393734bdd8c6b9356c2e4'  # checksum for 0.30.0
 
       vacuum-hard-mode:
         type: boolean
@@ -182,7 +182,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Lint
-        uses: maykinmedia/open-api-workflows/actions/oas-lint@cca0942e0fac0e83da00e8d3b9bbf540a9b06c7e # pre-v7.0.0
+        uses: maykinmedia/open-api-workflows/actions/oas-lint@02245b807e6b798d4a1716199b6b28e2f7da8bc8 # pre-v7.0.0
         with:
           schema-path: ${{ needs.generate-and-compare.outputs.schema-path }}
           vacuum-version: ${{ inputs.vacuum-version }}

--- a/actions/oas-lint/README.md
+++ b/actions/oas-lint/README.md
@@ -1,6 +1,6 @@
 # Lint OpenAPI specification
 
-Run the [spectral](https://www.npmjs.com/package/@stoplight/spectral-cli) linter on the
+Run the [vacuum](https://github.com/daveshanley/vacuum) linter on the
 specified OpenAPI specification.
 
 This action deliberately does not use the existing github action, as it appears to not
@@ -36,7 +36,7 @@ jobs:
         with:
           schema-path: ${{ needs.generate.outputs.schema-path }}
           node-version-file: '.nvmrc'
-          spectral-version: '^6.15.0'
+          vacuum-version: '0.30.0'
 ```
 
 Note that if you cleverly combine all the actions that you don't even need to check out

--- a/actions/oas-lint/action.yml
+++ b/actions/oas-lint/action.yml
@@ -1,9 +1,9 @@
 ---
 
-name: Lint the specified OpenAPI spec using spectral.
+name: Lint the specified OpenAPI spec using vacuum.
 
 description: >2
-  Installs and runs the spectral linter on the specified OpenAPI specification(s).
+  Installs and runs the vacuum linter on the specified OpenAPI specification(s).
 
 
   You can provide the API specification in a number of ways: checkout the repository
@@ -17,29 +17,26 @@ inputs:
     description: Path or glob (relative to the root of the repo) of specifications to lint.
     default: 'src/openapi.yaml'
 
-  node-version-file:
+  vacuum-version:
     type: string
     required: false
     description: >2
-      Passed down to actions/setup-node, so the same rules apply. Alternatively, use
-      `node-version` instead.
-    default: ''
+      The version of vacuum to install. It's recommended to pin this for stability reasons.
+    default: '0.30.0'
 
-  node-version:
+  vacuum-version-checksum:
     type: string
     required: false
     description: >2
-      Passed down to actions/setup-node, so the same rules apply. Alternatively, use
-      `node-version-file` instead.
-    default: ''
+      The sha256 checksum that should match for the given `vacuum-version`
+    default: '817b6bd71051c2b543891b4e26692404bfab9c79b29393734bdd8c6b9356c2e4'  # checksum for 0.30.0
 
-  spectral-version:
-    type: string
+  vacuum-hard-mode:
+    type: boolean
     required: false
     description: >2
-      The NPM package version number of spectral-cli to install. It's recommended
-      to pin this for stability reasons.
-    default: '^6.15.0'
+      Whether or not the --hard-mode flag should be enabled for vacuum linting
+    default: false
 
   ruleset:
     type: string
@@ -53,12 +50,6 @@ runs:
   using: composite
 
   steps:
-    - name: Setup Node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-      with:
-        node-version: ${{ inputs.node-version }}
-        node-version-file: ${{ inputs.node-version-file }}
-
     - name: Set up (default) ruleset
       run: |
         if [ ! -f .spectral.yaml ]; then
@@ -67,12 +58,27 @@ runs:
         fi
       shell: bash
 
-    - name: Install and run Spectral linter
+    - name: Install Vacuum from prebuilt binary
       run: |
-        npm install -g @stoplight/spectral-cli@${INPUTS_SPECTRAL_VERSION}
-        spectral lint ${INPUTS_SCHEMA_PATH} --ruleset ${INPUTS_RULESET}
+        wget https://github.com/daveshanley/vacuum/releases/download/v${INPUTS_VACUUM_VERSION}/vacuum_${INPUTS_VACUUM_VERSION}_linux_x86_64.tar.gz
+        echo "${INPUTS_VACUUM_VERSION_CHECKSUM} vacuum_${INPUTS_VACUUM_VERSION}_linux_x86_64.tar.gz" | sha256sum --check
+        tar -xzf vacuum_${INPUTS_VACUUM_VERSION}_linux_x86_64.tar.gz
+        sudo mv vacuum /usr/local/bin/
       shell: bash
       env:
-        INPUTS_SPECTRAL_VERSION: ${{ inputs.spectral-version }}
+        INPUTS_VACUUM_VERSION: ${{ inputs.vacuum-version }}
+        INPUTS_VACUUM_VERSION_CHECKSUM: ${{ inputs.vacuum-version-checksum }}
+
+    - name: Run Vacuum linter
+      run: |
+        echo "### Vacuum Lint Results" >> $GITHUB_STEP_SUMMARY
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+        vacuum lint ${INPUTS_SCHEMA_PATH} \
+          --ruleset ${INPUTS_RULESET} ${{ inputs.vacuum-hard-mode == 'true' && '--hard-mode' || '' }} \
+          --details --errors \
+          >> $GITHUB_STEP_SUMMARY 2>&1
+        echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+      shell: bash
+      env:
         INPUTS_SCHEMA_PATH: ${{ inputs.schema-path }}
         INPUTS_RULESET: ${{ inputs.ruleset }}

--- a/actions/oas-sdks/README.md
+++ b/actions/oas-sdks/README.md
@@ -35,7 +35,7 @@ jobs:
         with:
           schema-path: ${{ needs.generate.outputs.schema-path }}
           node-version-file: '.nvmrc'
-          spectral-version: '^6.15.0'
+          vacuum-version: '0.30.0'
 ```
 
 Note that if you cleverly combine all the actions that you don't even need to check out


### PR DESCRIPTION
spectral-cli installs unpinned dependencies which were compromised in a supply chain attack as of 14 july 2026, and vacuum should be faster as well

Runtime of lint OAS job before: ~18s for klantinteracties API https://github.com/maykinmedia/open-klant/actions/runs/28593964678/job/84784583554
After: ~5s https://github.com/maykinmedia/open-klant/actions/runs/30093130463/job/89480852028?pr=634

Fixes #60 

Example PRs:
* https://github.com/maykinmedia/open-klant/pull/634
* https://github.com/open-formulieren/open-forms/pull/6489

Example summary in Open Forms: https://github.com/open-formulieren/open-forms/actions/runs/30098584880
