### PR TITLE
:green_heart: [#64] Add action to generate and update Docker Hub description

### DIFF
--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,50 @@
+name: Generate and Update Docker Hub description
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: Name of the Docker Hub repository
+        required: true
+        type: string
+      config-file:
+        description: Path to the JSON configuration file containing project constants
+        required: false
+        default: ./docker/ci/config.json
+        type: string
+      output-file:
+        description: Path to the output file where the generated description will be written
+        required: false
+        default: ./docker/ci/README.md
+        type: string
+
+    secrets:
+      docker-username:
+        required: true
+      docker-token:
+        required: true
+
+permissions: {}
+
+jobs:
+  update-docker-readme:
+    name: Generate and update Docker Hub description
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Generate README
+        uses: maykinmedia/open-api-workflows/actions/dockerhub-description@ec61297c42c9e57db276e2731dca48b168679423
+        with:
+          config-file: ${{ inputs.config-file }}
+          output-file: ${{ inputs.output-file }}
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.docker-username }}
+          password: ${{ secrets.docker-token }}
+          repository: ${{ inputs.image-name }}
+          readme-filepath: ${{ inputs.output-file }}

--- a/actions/dockerhub-description/README.md
+++ b/actions/dockerhub-description/README.md
@@ -1,0 +1,20 @@
+# Generate Dockerhub Description
+
+This composite action generates a Docker Hub repository description from a JSON configuration file, rendered through a Jinja2 template.
+
+## Example usage
+
+```yaml
+- uses: actions/checkout@<ref>
+
+- name: Generate README
+  uses: maykinmedia/open-api-workflows/actions/dockerhub-description@<ref>
+  with:
+    config-file: './docker/ci/config.json'
+    output-file: './docker/ci/README.md'
+```
+
+- `config-file`: Path in your project to the JSON file with project configurations. Default: `./docker/ci/config.json`.
+- `output-file`: Path in your project where the rendered README will be written. Default: `./docker/ci/README.md`.
+
+Both paths are resolved relative to your project's repository, not to `open-api-workflows`, make sure `actions/checkout` runs before this step and that `config-file` exists at that path.

--- a/actions/dockerhub-description/action.yml
+++ b/actions/dockerhub-description/action.yml
@@ -1,0 +1,25 @@
+name: Generate Docker Hub description
+description: 'Generates the README file used as the Docker Hub description from a constants file'
+
+inputs:
+  config-file:
+    description: Path to the JSON configuration file containing project constants
+  output-file:
+    description: Path to the output file where the generated description will be written
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      with:
+        enable-cache: false
+
+    - name: Run generator script
+      shell: bash
+      run: |
+        uv run --no-project "${{ github.action_path }}/generate_dockerhub_description.py" \
+          --config-file="${INPUTS_CONFIG_FILE}" \
+          --output-file="${INPUTS_OUTPUT_FILE}"
+      env:
+        INPUTS_CONFIG_FILE: ${{ inputs.config-file }}
+        INPUTS_OUTPUT_FILE: ${{ inputs.output-file }}

--- a/actions/dockerhub-description/dockerhub_readme.md.j2
+++ b/actions/dockerhub-description/dockerhub_readme.md.j2
@@ -1,0 +1,50 @@
+# {{ project_name }} - Official Docker image
+
+## Quick reference
+
+- **Documentation**: {{ project_documentation }}
+- **Maintained by**: [The {{ project_name }} Maintainers](https://github.com/{{ github_org }})
+- **Where to get help**: [The {{ project_name }} Github](https://github.com/{{ github_org }}/{{ github_repo }}/issues)
+
+## Supported tags and respective `Dockerfile` links
+
+{% for supported_tag in supported_tags %}{% if not supported_tag.has_extensions -%}
+- [`{{ supported_tag.tag }}`]({{ supported_tag.dockerfile_url }})
+{% endif %}{% endfor %}
+
+## Quick reference (cont.)
+
+- **Supported architectures**: `amd64`
+
+## What is {{ project_name }}?
+
+{{ project_description }}
+
+{% if project_docker_usage_url %}
+## Usage
+
+See: {{ project_docker_usage_url }}
+{% endif %}
+{% if extensions %}
+## Extensions
+
+The {{ project_name }} maintainers also maintain a number of official extensions, which are
+distributed in a separate build, including all available extensions _at the time_.
+
+### Supported tags with extensions
+
+{% for supported_tag in supported_tags %}{% if supported_tag.has_extensions -%}
+- [`{{ supported_tag.tag }}`]({{ supported_tag.dockerfile_url }})
+{% endif %}{% endfor %}
+
+**Included extensions**
+
+The extensions bundled in the `latest` build are:
+
+{% for extension in extensions -%}
+- [{{ extension.name }}](https://github.com/{{ extension.repository }})
+{% endfor %}
+
+Note that _versioned_ tags may include fewer extensions than `latest`, depending on
+which extensions were available during that release cycle.
+{% endif %}

--- a/actions/dockerhub-description/generate_dockerhub_description.py
+++ b/actions/dockerhub-description/generate_dockerhub_description.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python
+#
+# The configuration for the README generation lives in ./config.json
+#
+# /// script
+# dependencies = [
+#   "jinja2~=3.1.6",
+#   "msgspec~=0.19.0",
+#   "requests~=2.32.4",
+#   "typer~=0.27.0",
+# ]
+# ///
+#
+# Usage from the root of the repository:
+#
+# .. code-block:: bash
+#
+#     uv run ./docker/ci/generate_dockerhub_description.py --config-file=<config-file> --output-file=<output-file>
+#
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated
+
+import msgspec
+import requests
+import typer
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+app = typer.Typer()
+
+STABLE_PREFIX = "stable/"
+RE_SEMVER_TAG = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+README_TEMPLATE = "dockerhub_readme.md.j2"
+
+
+class TagConfiguration(msgspec.Struct):
+    gitRef: str
+    tag: str | None = None
+
+
+class ProjectConfig(msgspec.Struct):
+    supportedTags: list[TagConfiguration]
+    dockerOrg: str
+    dockerRepo: str
+    githubOrg: str
+    githubRepo: str
+    projectName: str
+    projectDocumentation: str
+    projectDescription: str
+    projectDockerUsageUrl: str = ""
+
+
+@dataclass
+class SupportedTag:
+    tag: str
+    git_ref: str
+    git_org: str
+    git_repo: str
+
+    @property
+    def dockerfile_url(self) -> str:
+        return f"https://github.com/{self.git_org}/{self.git_repo}/blob/{self.git_ref}/Dockerfile"
+
+
+class DockerReadmeGenerator:
+    def __init__(self, config_file: ProjectConfig):
+        self.config = self._load_config(config_file)
+
+    def _load_config(self, config_file: Path) -> ProjectConfig:
+        raw = config_file.read_bytes()
+        try:
+            return msgspec.json.decode(raw, type=ProjectConfig)
+        except msgspec.ValidationError as exc:
+            raise ValueError(f"Invalid configuration in {config_file}: {exc}") from exc
+        except msgspec.DecodeError as exc:
+            raise ValueError(f"Malformed JSON in {config_file}: {exc}") from exc
+
+    def get_tag_names_on_dockerhub(self) -> list[str]:
+        tag_names = []
+
+        def _handle_response(response) -> dict:
+            response.raise_for_status()
+            response_data = response.json()
+            tag_names.extend(tag["name"] for tag in response_data["results"])
+            return response_data
+
+        with requests.Session() as session:
+            response = session.get(
+                f"https://hub.docker.com/v2/namespaces/{self.config.dockerOrg}/repositories/{self.config.dockerRepo}/tags",
+                params={"page_size": 10},
+            )
+            response_data = _handle_response(response)
+            while next_page := response_data["next"]:
+                response = session.get(next_page)
+                response_data = _handle_response(response)
+
+        # filter down to semver tags
+        return [name for name in tag_names if RE_SEMVER_TAG.match(name)]
+
+    def get_supported_tags(self) -> Iterator[SupportedTag]:
+        tag_configurations = self.config.supportedTags
+        existing_tags = self.get_tag_names_on_dockerhub()
+
+        for cfg in tag_configurations:
+            git_ref = cfg.gitRef
+            is_stable = git_ref.startswith(STABLE_PREFIX)
+            inferred_tag = (
+                git_ref.replace(STABLE_PREFIX, "", 1) if is_stable else git_ref
+            )
+            tag = cfg.tag or inferred_tag
+            explicit_supported_tag = SupportedTag(
+                tag=tag,
+                git_ref=git_ref,
+                git_org=self.config.githubOrg,
+                git_repo=self.config.githubRepo,
+            )
+
+            if not is_stable:
+                yield explicit_supported_tag
+                continue
+
+            # find the most recent concrete tag for the stable version
+            major, minor, _ = inferred_tag.split(".")
+            matching_tags = [
+                t for t in existing_tags if t.startswith(f"{major}.{minor}.")
+            ]
+            if not matching_tags:
+                continue
+
+            most_recent = max(matching_tags, key=lambda t: int(t.rsplit(".", 1)[-1]))
+
+            yield SupportedTag(
+                tag=most_recent,
+                git_ref=most_recent,
+                git_org=self.config.githubOrg,
+                git_repo=self.config.githubRepo,
+            )
+            yield explicit_supported_tag
+
+    def render(self) -> str:
+        context = {
+            "project_name": self.config.projectName,
+            "project_documentation": self.config.projectDocumentation,
+            "project_description": self.config.projectDescription,
+            "project_docker_usage_url": self.config.projectDockerUsageUrl,
+            "github_org": self.config.githubOrg,
+            "github_repo": self.config.githubRepo,
+            "supported_tags": list(self.get_supported_tags()),
+        }
+        template_dir = Path(__file__).parent
+        env = Environment(
+            loader=FileSystemLoader(template_dir), autoescape=select_autoescape()
+        )
+        template = env.get_template(README_TEMPLATE)
+        return template.render(context)
+
+    def write(self, output_file: Path) -> None:
+        content = self.render()
+        with output_file.open("w") as outfile:
+            outfile.write(content)
+
+        typer.echo(f"README file generated at: '{output_file}'")
+
+
+@app.command()
+def main(
+    config_file: Annotated[
+        Path,
+        typer.Option(
+            help="Path to the JSON configuration file containing project constants."
+        ),
+    ] = Path("./docker/ci/config.json"),
+    output_file: Annotated[
+        Path,
+        typer.Option(
+            help="Path to the output file where the generated description will be written."
+        ),
+    ] = Path("./docker/ci/README.md"),
+):
+    generator = DockerReadmeGenerator(config_file=config_file)
+    generator.write(output_file)
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
I took a the script from Open-Forms and tried to improve it using Typer, then implemented it in an action and then in workflow

Partially fixes #64 

Workflow tested in OpenVTB: https://github.com/maykinmedia/open-vtb/pull/172

Docker desc: https://hub.docker.com/r/maykinmedia/open-vtb


**NEW DESC**


Tested in all projects with CI and OpenForms manually:
I've temporarily added an action to display the README, because DOCKER_USERNAME currently doesn't have the necessary permissions to push to Docker

Here is the action for all components:


- [] Open Zaak https://github.com/open-zaak/open-zaak/actions/runs/30795821950/job/91629048183?pr=2485
- [] Open Notificaties https://github.com/open-zaak/open-notificaties/actions/runs/30795847167/job/91629128686?pr=416
- [] Open Object https://github.com/maykinmedia/open-object/actions/runs/30796035327/job/91629714028?pr=805
- [] Open Klant https://github.com/maykinmedia/open-klant/actions/runs/30795786297/job/91628933693?pr=647
- [] Open Product https://github.com/maykinmedia/open-product/actions/runs/30795906551/job/91629318977?pr=349
- [] Referentielijsten https://github.com/maykinmedia/referentielijsten/actions/runs/30795963834/job/91629496103?pr=171
- [] Open VTB
- [] Open Organisatie https://github.com/maykinmedia/open-organisatie/actions/runs/30795690580/job/91628637448?pr=165

